### PR TITLE
Automatic preamble support and Error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ Content inside of `tikz` code blocks will be rendered by TikZJax.
 - The standalone document class is used (`\documentclass{standalone}`).
 
 ### Preamble Support
-You can create a `tikz-preamble.tex` file to define common packages and commands that will be automatically included in all TikZ diagrams. The plugin searches for this file in the following locations (in order):
+You can create a `tikz-preamble.tex` file to define common packages and commands that will be automatically included in all TikZ diagrams. The plugin searches for this file starting from your current note's directory and walking up the directory tree to the vault root, using the **first file found**.
 
-1. Same directory as your current note
-2. Parent directories (walking up the directory tree)
-3. Vault root directory
+This allows you to:
+- **Simplify TikZ code blocks** by moving common setup to the preamble
+- **Organize by topic** using different preambles in different folders
+- **Inherit settings** from parent directories when no local preamble exists
 
 **Example `tikz-preamble.tex`:**
 ```latex
@@ -55,12 +56,13 @@ With this preamble file, you can write simpler TikZ code blocks:
 ```
 ````
 
-### Enhanced Error Reporting
-When TikZ compilation fails, the plugin displays intelligent error messages that filter out noise and focus on the actual problems:
+### Error Reporting
+When TikZ compilation fails, the plugin now displays detailed error messages directly below the code block. The error display intelligently filters LaTeX output to show only relevant information:
 
-- **Preamble errors** (before `\begin{document}`): Shows package conflicts, command redefinitions, etc.
-- **Document errors** (after `\begin{document}`): Shows syntax errors, missing brackets, undefined commands, etc.
-- **Filtered output**: Automatically hides normal library loading messages and shows only relevant error information.
+- **Preamble errors** (before `\begin{document}`): Package conflicts, command redefinitions, etc.
+- **Document errors** (after `\begin{document}`): Syntax errors, missing brackets, undefined commands, etc.
+- **Smart filtering**: Automatically hides normal library loading messages and focuses on actual problems
+- **Inline display**: Errors appear directly in your note, making debugging much easier
 
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -25,6 +25,43 @@ Content inside of `tikz` code blocks will be rendered by TikZJax.
 
 - The standalone document class is used (`\documentclass{standalone}`).
 
+### Preamble Support
+You can create a `tikz-preamble.tex` file to define common packages and commands that will be automatically included in all TikZ diagrams. The plugin searches for this file in the following locations (in order):
+
+1. Same directory as your current note
+2. Parent directories (walking up the directory tree)
+3. Vault root directory
+
+**Example `tikz-preamble.tex`:**
+```latex
+\usepackage{tikz}
+\usepackage{pgfplots}
+\usepackage{circuitikz}
+\usetikzlibrary{arrows.meta, positioning}
+
+% Custom commands
+\newcommand{\myarrow}[1]{\draw[->] #1;}
+\pgfplotsset{compat=1.16}
+```
+
+With this preamble file, you can write simpler TikZ code blocks:
+````latex
+```tikz
+\begin{document}
+\begin{tikzpicture}
+  \myarrow{(0,0) -- (1,1)}
+\end{tikzpicture}
+\end{document}
+```
+````
+
+### Enhanced Error Reporting
+When TikZ compilation fails, the plugin displays intelligent error messages that filter out noise and focus on the actual problems:
+
+- **Preamble errors** (before `\begin{document}`): Shows package conflicts, command redefinitions, etc.
+- **Document errors** (after `\begin{document}`): Shows syntax errors, missing brackets, undefined commands, etc.
+- **Filtered output**: Automatically hides normal library loading messages and shows only relevant error information.
+
 
 ### Examples
 <img width=300 align="right" src="./imgs/img1.png">

--- a/main.ts
+++ b/main.ts
@@ -369,7 +369,10 @@ export default class TikzjaxPlugin extends Plugin {
 				const isNormalDocument = (
 					/^No file input\.aux\./.test(trimmed) ||
 					/^ABD:/.test(trimmed) ||
-					/^\("input\.aux"\)/.test(trimmed)
+					/^\("input\.aux"\)/.test(trimmed) ||
+					/^\(input\.aux\)/.test(trimmed) ||
+					/^Output written on input\.dvi/.test(trimmed) ||
+					/^Transcript written on input\.log/.test(trimmed)
 				);
 				if (isNormalDocument) {
 					continue;

--- a/main.ts
+++ b/main.ts
@@ -93,13 +93,22 @@ export default class TikzjaxPlugin extends Plugin {
 
 
 	registerTikzCodeBlock() {
-		this.registerMarkdownCodeBlockProcessor("tikz", (source, el, ctx) => {
+		this.registerMarkdownCodeBlockProcessor("tikz", async (source, el, ctx) => {
+			console.log("TikZJax-wskorng: Processing tikz block");
+			console.log("Source path:", ctx.sourcePath);
+			
 			const script = el.createEl("script");
 
 			script.setAttribute("type", "text/tikz");
 			script.setAttribute("data-show-console", "true");
 
-			script.setText(this.tidyTikzSource(source));
+			const preamble = await this.findPreambleFile(ctx.sourcePath);
+			console.log("Found preamble:", preamble ? `${preamble.length} characters` : "none");
+			
+			const finalSource = this.tidyTikzSource(source, preamble);
+			console.log("Final TikZ source:", finalSource);
+			
+			script.setText(finalSource);
 		});
 	}
 
@@ -114,7 +123,51 @@ export default class TikzjaxPlugin extends Plugin {
 		window.CodeMirror.modeInfo = window.CodeMirror.modeInfo.filter(el => el.name != "Tikz");
 	}
 
-	tidyTikzSource(tikzSource: string) {
+	async findPreambleFile(sourcePath: string): Promise<string> {
+		if (!sourcePath) {
+			console.log("TikZJax-wskorng: No source path provided");
+			return "";
+		}
+		
+		console.log("TikZJax-wskorng: Searching for preamble file from:", sourcePath);
+		
+		// Split path into parts and work backwards
+		const pathParts = sourcePath.split('/');
+		
+		// Try multiple filename patterns in order of preference
+		const preambleFilenames = ['.tikz-preamble.tex', '.tikz-preamble', 'tikz-preamble.tex'];
+		
+		for (let i = pathParts.length - 1; i >= 0; i--) {
+			const currentPath = pathParts.slice(0, i).join('/');
+			
+			for (const filename of preambleFilenames) {
+				const preamblePath = currentPath ? `${currentPath}/${filename}` : filename;
+				console.log("TikZJax-wskorng: Checking path:", preamblePath);
+				
+				try {
+					// @ts-ignore - this.app is available in Plugin class
+					const file = this.app.vault.getAbstractFileByPath(preamblePath);
+					console.log("TikZJax-wskorng: File found:", !!file);
+					
+					// @ts-ignore - TFile type check
+					if (file && file instanceof this.app.vault.TFile) {
+						console.log("TikZJax-wskorng: Reading file:", preamblePath);
+						// @ts-ignore - vault.read method
+						const content = await this.app.vault.read(file);
+						console.log("TikZJax-wskorng: Preamble content loaded:", content.substring(0, 100) + "...");
+						return content;
+					}
+				} catch (error) {
+					console.log("TikZJax-wskorng: Error reading file:", preamblePath, error);
+				}
+			}
+		}
+		
+		console.log("TikZJax-wskorng: No preamble file found");
+		return "";
+	}
+
+	tidyTikzSource(tikzSource: string, preamble: string = "") {
 
 		// Remove non-breaking space characters, otherwise we get errors
 		const remove = "&nbsp;";
@@ -129,6 +182,11 @@ export default class TikzjaxPlugin extends Plugin {
 		// Remove empty lines
 		lines = lines.filter(line => line);
 
+		// Insert preamble if available
+		if (preamble.trim()) {
+			const preambleLines = preamble.trim().split("\n");
+			lines = [...preambleLines, ...lines];
+		}
 
 		return lines.join("\n");
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "obsidian-tikzjax",
+	"id": "obsidian-tikzjax-wskorng",
 	"name": "TikZJax",
-	"version": "0.5.2",
+	"version": "0.5.2-wskorng",
 	"minAppVersion": "0.12.0",
-	"description": "Render LaTeX and TikZ diagrams in your notes",
-	"author": "artisticat",
-	"authorUrl": "https://github.com/artisticat1",
+	"description": "Render LaTeX and TikZ diagrams in your notes with custom preamble",
+	"author": "wskorng",
+	"authorUrl": "https://github.com/wskorng",
 	"isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "obsidian-tikzjax-wskorng",
+	"id": "obsidian-tikzjax",
 	"name": "TikZJax",
-	"version": "0.5.2-wskorng",
+	"version": "0.5.2",
 	"minAppVersion": "0.12.0",
-	"description": "Render LaTeX and TikZ diagrams in your notes with custom preamble",
-	"author": "wskorng",
-	"authorUrl": "https://github.com/wskorng",
+	"description": "Render LaTeX and TikZ diagrams in your notes",
+	"author": "artisticat1",
+	"authorUrl": "https://github.com/artisticat1",
 	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "obsidian-tikzjax",
-	"version": "0.3.0",
+	"name": "obsidian-tikzjax-wskorng",
+	"version": "0.5.2-wskorng",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-tikzjax",
-			"version": "0.3.0",
+			"name": "obsidian-tikzjax-wskorng",
+			"version": "0.5.2-wskorng",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -16,6 +16,7 @@
 				"builtin-modules": "^3.2.0",
 				"esbuild": "0.13.12",
 				"esbuild-plugin-inline-import": "^1.0.1",
+				"localforage": "^1.9.0",
 				"obsidian": "latest",
 				"pako": "^2.0.4",
 				"tslib": "2.3.1",
@@ -1308,6 +1309,13 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1429,6 +1437,26 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"node_modules/localforage": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+			"integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lie": "3.1.1"
 			}
 		},
 		"node_modules/locate-path": {
@@ -2943,6 +2971,12 @@
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"dev": true
 		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true
+		},
 		"import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3040,6 +3074,24 @@
 			"requires": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			}
+		},
+		"lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+			"dev": true,
+			"requires": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"localforage": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+			"integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+			"dev": true,
+			"requires": {
+				"lie": "3.1.1"
 			}
 		},
 		"locate-path": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-tikzjax",
-	"version": "0.5.2",
-	"description": "Render LaTeX and TikZ diagrams in your notes",
+	"name": "obsidian-tikzjax-wskorng",
+	"version": "0.5.2-wskorng",
+	"description": "Render LaTeX and TikZ diagrams in your notes with custom preamble",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
@@ -9,7 +9,7 @@
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
-	"author": "",
+	"author": "wskorng",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-tikzjax-wskorng",
-	"version": "0.5.2-wskorng",
-	"description": "Render LaTeX and TikZ diagrams in your notes with custom preamble",
+	"name": "obsidian-tikzjax",
+	"version": "0.5.2",
+	"description": "Render LaTeX and TikZ diagrams in your notes",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
@@ -9,7 +9,7 @@
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
-	"author": "wskorng",
+	"author": "artisticat1",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/node": "^16.11.6",


### PR DESCRIPTION
I'm using obsidian-tikzjax customized for my own use. 
I'm submitting it as a pull request because it's very convenient :)
I apologize for combining two unrelated features into a single pull request.

## Feature 1. Automatic Preamble Support
This will be an alternative solution of #76 .
- Searches for `tikz-preamble.tex` starting from current note's directory to vault root, walking up to find the first match
- Automatically prepends found preamble to TikZ code before compilation
- Enables folder-based organization with topic-specific preambles
- Simplifies code blocks by moving boilerplate to reusable preambles
- If any `tikz-preamble.tex` were not found, compiles without adding anything as before

This feature's implementation is based on #77, and the point that "The preamble processing should precede the creation of the script element" was extremely helpful. Thanks to @mozhewen!

## Feature 2. Error Reporting
This will be the first-time solution of #81 .
- Shows compilation errors inline below TikZ code blocks
- Intelligent filtering separates preamble vs document phase errors
- Filters out library loading noise, focuses on actual problems

Example:
<img width="714" height="588" alt="スクリーンショット 2025-10-16 3 33 43" src="https://github.com/user-attachments/assets/751d6483-d736-4480-bfaf-4ab2be7a1186" />

This feature is implemented by peeping at console.log via monkey-patching. It's not a very clean way, but it seems to be the only way.